### PR TITLE
Add Cargo lockfile to semver bump commit assets

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -20,7 +20,8 @@
         {
           "assets": [
             "CHANGELOG.md",
-            "Cargo.toml"
+            "Cargo.toml",
+            "Cargo.lock"
           ],
           "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}\n\n\nskip-checks: true"
         }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "katbin"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "atty",


### PR DESCRIPTION
The crate version is also part of the Cargo lockfile and mismatches result in build failure in environments like Nix.
