### PR TITLE
chore(ci): add build targets for Windows and macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,25 @@ on:
 
 jobs:
   release:
-    name: Release
-    runs-on: ubuntu-latest
+    name: ${{ matrix.job.target }} (${{ matrix.job.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - {
+              target: x86_64-unknown-linux-gnu,
+              os: ubuntu-latest,
+              use-cross: true,
+            }
+          - {
+              target: x86_64-unknown-linux-musl,
+              os: ubuntu-latest,
+              use-cross: true,
+            }
+          - { target: x86_64-apple-darwin, os: macos-latest, use-cross: true }
+          - { target: x86_64-pc-windows-gnu, os: windows-latest }
+          - { target: x86_64-pc-windows-msvc, os: windows-latest }
+    runs-on: ${{ matrix.job.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@3ba5ee6fac7e0e30e2ea884e236f282d3a775891
@@ -29,11 +46,12 @@ jobs:
         with:
           make-default: true
 
-      - name: Install Rust toolchain (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        run:
-          curl https://sh.rustup.rs -sSf | sh -s -- --profile default --default-toolchain stable -y
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          override: true
 
       - name: Cache cargo registry and build outputs
         uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
@@ -42,7 +60,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/bin
             target
-          key: linux-cargo-stable-${{ hashFiles('Cargo.lock') }}
+          key: ${{ matrix.job.target }}-cargo-stable-${{ hashFiles('Cargo.lock') }}
 
       - name: Install cargo-edit
         uses: baptiste0928/cargo-install@v1
@@ -50,24 +68,38 @@ jobs:
           crate: cargo-edit
           version: "0.11.6"
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: x86_64-unknown-linux-gnu
-          override: true
-      - name: Build x86 linux binary
+      - name: Build ${{ matrix.job.target }} binary
         uses: actions-rs/cargo@v1
         with:
-          use-cross: true
+          use-cross: ${{ matrix.job.use-cross }}
           command: build
-          args: --release --target x86_64-unknown-linux-gnu
+          args: --release --target=${{ matrix.job.target }}
 
-      - name: Copy targets
+      - name: Copy release build targets
+        id: build
+        shell: bash
         run: |
           mkdir dist
-          mv target/x86_64-unknown-linux-gnu/release/katbin dist/katbin-x86_64-unknown-linux-gnu
 
-      - name: Release
+          EXE_suffix=""
+          case ${{ matrix.job.target }} in
+            *-pc-windows-*) EXE_suffix=".exe" ;;
+          esac;
+
+          BIN_NAME="katbin-${{ matrix.job.target }}${EXE_suffix}"
+
+          mv target/${{ matrix.job.target }}/release/katbin${EXE_suffix} dist/${BIN_NAME}
+
+          echo "BIN_NAME=${BIN_NAME}" >> $GITHUB_OUTPUT
+          echo "BIN_PATH=dist/${BIN_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Upload ${{ matrix.job.target }} binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: katbin-${{ matrix.job.target }}
+          path: ${{ steps.build.outputs.BIN_PATH }}
+
+      - name: Publish Release
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add more build targets and also upload them to CI artifacts

[Test Action](https://github.com/Yash-Garg/katbin-cli/actions/runs/4701329587)